### PR TITLE
Remove built-in breakpoints + minor improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arm7tdmi-rs"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Sean Purcell <me@seanp.xyz>", "Daniel Prilik <danielprilik@gmail.com>"]
 edition = "2018"
 

--- a/src/arm.rs
+++ b/src/arm.rs
@@ -111,7 +111,7 @@ impl Cpu {
         }
         #[cfg(feature = "advanced_disasm")]
         {
-            if log::max_level().to_level() == Some(log::Level::Trace) {
+            if log_enabled!(log::Level::Trace) {
                 let cs = self.cs.as_mut().unwrap();
                 cs.set_mode(capstone::Mode::Arm).unwrap();
                 if let Ok(inst) = cs.disasm_count(&inst.to_le_bytes(), pc as u64, 1) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,7 @@ impl Cpu {
         self.reg.set(bank, reg, val)
     }
 
-    pub fn reg_get(&mut self, bank: usize, reg: Reg) -> u32 {
+    pub fn reg_get(&self, bank: usize, reg: Reg) -> u32 {
         self.reg.get(bank, reg)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@
 )]
 #![warn(clippy::bad_bit_mask)] // TODO: remove this once warning is resolved
 
-use std::collections::HashSet;
 use std::default::Default;
 use std::iter::IntoIterator;
 
@@ -74,13 +73,16 @@ pub trait Memory {
 pub struct Cpu {
     /// Registers
     reg: RegFile,
-    /// Breakpoints
-    #[cfg_attr(feature = "serde", serde(skip))]
-    brk: HashSet<u32>,
     /// Disassembler
     #[cfg(feature = "advanced_disasm")]
     #[cfg_attr(feature = "serde", serde(skip))]
     cs: Option<Capstone>,
+}
+
+impl std::fmt::Debug for Cpu {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        fmt.debug_struct("Cpu").field("reg", &self.reg).finish()
+    }
 }
 
 impl Cpu {
@@ -88,7 +90,6 @@ impl Cpu {
     pub fn new<'a>(regs: impl IntoIterator<Item = &'a (usize, Reg, u32)>) -> Self {
         let mut cpu = Cpu {
             reg: Default::default(),
-            brk: Default::default(),
             #[cfg(feature = "advanced_disasm")]
             cs: Some(
                 Capstone::new()
@@ -108,23 +109,10 @@ impl Cpu {
         cpu
     }
 
-    /// Add breakpoints at certain memory addresses
-    pub fn set_breaks<'a>(&mut self, brks: impl IntoIterator<Item = &'a u32>) {
-        for addr in brks.into_iter() {
-            self.brk.insert(*addr);
-        }
-    }
-
     /// Tick the CPU a single cycle
     pub fn cycle(&mut self, mmu: &mut impl Memory) -> bool {
-        if self.brk.contains(&self.reg[reg::PC]) {
-            warn!("Breakpoint {:#010x} hit!", self.reg[reg::PC]);
-            at_breakpoint();
-        }
-
         let mut mmu = AlignmentWrapper::new(mmu);
 
-        at_cycle();
         if !self.thumb_mode() {
             self.execute_arm(&mut mmu)
         } else {
@@ -182,7 +170,3 @@ impl Cpu {
         self.reg.get(bank, reg)
     }
 }
-
-// These are functions to set breakpoints on for debugging
-fn at_breakpoint() {}
-fn at_cycle() {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,4 +169,8 @@ impl Cpu {
     pub fn reg_get(&self, bank: usize, reg: Reg) -> u32 {
         self.reg.get(bank, reg)
     }
+
+    pub fn get_mode(&self) -> mode::Mode {
+        self.reg.mode()
+    }
 }

--- a/src/reg.rs
+++ b/src/reg.rs
@@ -36,6 +36,33 @@ pub struct RegFile {
     bank: usize,
 }
 
+// This is pretty jank, due to the way registers are stored
+// It could use some improvement.
+impl std::fmt::Debug for RegFile {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let mut builder = fmt.debug_struct("RegFile");
+        builder.field("curr_bank", &self.bank);
+        for (bank, map) in REG_MAP.iter().enumerate() {
+            let mut regs = Vec::new();
+            for reg in map.iter().copied() {
+                match reg as u8 {
+                    SP => regs.push(("SP".to_string(), self.reg[reg])),
+                    LR => regs.push(("LR".to_string(), self.reg[reg])),
+                    PC => regs.push(("PC".to_string(), self.reg[reg])),
+                    CPSR => regs.push(("CPSR".to_string(), self.reg[reg])),
+                    SPSR => regs.push(("SPSR".to_string(), self.reg[reg])),
+                    _ => regs.push((format!("r{}", reg), self.reg[reg])),
+                };
+            }
+            builder.field(
+                format!("bank{}", bank).as_str(),
+                &format!("{:x?}", regs).replace("\"", ""),
+            );
+        }
+        builder.finish()
+    }
+}
+
 impl RegFile {
     #[inline]
     pub fn mode(&self) -> Mode {

--- a/src/reg.rs
+++ b/src/reg.rs
@@ -23,12 +23,12 @@ pub const SPSR: Reg = 17;
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
 const REG_MAP: [[usize; 18]; 6] = [
-    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16],
-    [0, 1, 2, 3, 4, 5, 6, 7, 17, 18, 19, 20, 21, 22, 23, 15, 16, 24],
-    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 25, 26, 15, 16, 27],
-    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 28, 29, 15, 16, 30],
-    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 31, 32, 15, 16, 33],
-    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 34, 35, 15, 16, 36],
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16],   // user
+    [0, 1, 2, 3, 4, 5, 6, 7, 17, 18, 19, 20, 21, 22, 23, 15, 16, 24], // fiq
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 25, 26, 15, 16, 27],   // irq
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 28, 29, 15, 16, 30],   // supervisor
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 31, 32, 15, 16, 33],   // abort
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 34, 35, 15, 16, 36],   // undefined
 ];
 
 pub struct RegFile {
@@ -41,22 +41,30 @@ pub struct RegFile {
 impl std::fmt::Debug for RegFile {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
         let mut builder = fmt.debug_struct("RegFile");
-        builder.field("curr_bank", &self.bank);
+        builder.field("cur_bank", &self.bank);
         for (bank, map) in REG_MAP.iter().enumerate() {
             let mut regs = Vec::new();
-            for reg in map.iter().copied() {
-                match reg as u8 {
+            for (i, reg) in map.iter().copied().enumerate() {
+                match i as u8 {
                     SP => regs.push(("SP".to_string(), self.reg[reg])),
                     LR => regs.push(("LR".to_string(), self.reg[reg])),
                     PC => regs.push(("PC".to_string(), self.reg[reg])),
                     CPSR => regs.push(("CPSR".to_string(), self.reg[reg])),
                     SPSR => regs.push(("SPSR".to_string(), self.reg[reg])),
-                    _ => regs.push((format!("r{}", reg), self.reg[reg])),
+                    _ => regs.push((format!("r{}", i), self.reg[reg])),
                 };
             }
             builder.field(
-                format!("bank{}", bank).as_str(),
-                &format!("{:x?}", regs).replace("\"", ""),
+                match bank {
+                    0 => "user       ",
+                    1 => "fiq        ",
+                    2 => "irq        ",
+                    3 => "supervisor ",
+                    4 => "abort      ",
+                    5 => "undefined  ",
+                    _ => unreachable!(),
+                },
+                &format!("{:08x?}", regs).replace("\"", ""),
             );
         }
         builder.finish()

--- a/src/thumb.rs
+++ b/src/thumb.rs
@@ -112,7 +112,7 @@ impl Cpu {
         }
         #[cfg(feature = "advanced_disasm")]
         {
-            if log::max_level().to_level() == Some(log::Level::Trace) {
+            if log_enabled!(log::Level::Trace) {
                 let cs = self.cs.as_mut().unwrap();
                 cs.set_mode(capstone::Mode::Thumb).unwrap();
                 if let Ok(inst) = cs.disasm_count(&inst.to_le_bytes(), pc as u64, 1) {


### PR DESCRIPTION
The two new register accessor methods make it possible to implement breakpoints outside of the CPU itself (i.e: checking the PC before calling `step`). 

For a more robust debugging experience, check out [`gdbstub`](https://github.com/daniel5151/gdbstub), a crate which implements the GDB remote serial protocol. I've been using it in some of my own projects which use `arm7tdmi-rs`, and it's been a huge step-up in usability.

---

Other minor changes include some additional `fmt::Debug` implementations for the CPU, and a couple of misc. logging tweaks.