### PR TITLE
lib: Add x16/x32 optional trait functions for instruction interface

### DIFF
--- a/src/arm.rs
+++ b/src/arm.rs
@@ -94,7 +94,7 @@ impl Cpu {
     /// executing.
     pub(crate) fn execute_arm(&mut self, mmu: &mut impl Memory) -> bool {
         let pc = self.reg[reg::PC];
-        let inst = mmu.r32(pc);
+        let inst = mmu.x32(pc);
         let inst_type = self::Instruction::decode(inst);
 
         let cond = inst.extract(28, 4);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,15 @@ pub trait Memory {
     fn w16(&mut self, addr: u32, val: u16);
     /// Write a 32-bit `val` to `addr`
     fn w32(&mut self, addr: u32, val: u32);
+
+    /// Read a 16-bit value from `addr`, instruction interface (defaults to data interface)
+    fn x16(&mut self, addr: u32) -> u16 {
+        self.r16(addr)
+    }
+    /// Read a 32-bit value from `addr`, instruction interface (defaults to data interface)
+    fn x32(&mut self, addr: u32) -> u32 {
+        self.r32(addr)
+    }
 }
 
 /// An emulated CPU which implements the ARMv4T instruction set.

--- a/src/thumb.rs
+++ b/src/thumb.rs
@@ -99,7 +99,7 @@ impl Cpu {
     /// executing.
     pub(crate) fn execute_thumb(&mut self, mmu: &mut impl Memory) -> bool {
         let pc = self.reg[reg::PC];
-        let inst = mmu.r16(pc) as u32;
+        let inst = mmu.x16(pc) as u32;
         let inst_type = self::Instruction::decode(inst as u16);
         let cpsr = self.reg[reg::CPSR];
         let c = cpsr.get_bit(cpsr::C);


### PR DESCRIPTION
ARM9TDMI has a Harvard bus architecture with split instruction and data interfaces (see [DDI0168](https://developer.arm.com/documentation/ddi0168/a/arm9tdmi-processor-core-memory-interface/about-the-memory-interface?lang=en), "3.1 About the memory interface"). The instruction interface memory accesses are exposed as "x16" and "x32" functions in the Memory trait. Their implementation is optional, and default to the current "r16" and "r32" functions.

This change might be useful when implementing cache/memory controllers that discriminate code and data memory accesses.